### PR TITLE
Allow passing in owner key to add mention to root post

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ You can pass special attributes to that `<script>` tag, such as
 
 - `data-relays='["wss://my.custom.relay", "..."]'`, a JSON list of relay URLs to use instead of the default ones;
 - `data-skip="/"`, a path of your website to skip rendering the widgets in. The default is `"/"`.
+- `data-owner='hex public key'`, a string with the post owner's public key in hex format.
 
 Custom CSS variables for styling:
 

--- a/embeddable/embed.jsx
+++ b/embeddable/embed.jsx
@@ -14,10 +14,11 @@ const relays = script.dataset.relays
       'wss://relay.damus.io'
     ]
 const skip = script.dataset.skip || '/'
+const owner = script.dataset.owner || ''
 
 const container = document.createElement('div')
 container.style.width = '100%'
 script.parentNode.insertBefore(container, script)
 
 const root = createRoot(container)
-root.render(<NoComment skip={skip} relays={relays} />)
+root.render(<NoComment skip={skip} relays={relays} owner={owner} />)

--- a/src/NoComment.jsx
+++ b/src/NoComment.jsx
@@ -26,6 +26,7 @@ import Thread, {computeThreads} from './Thread'
 export function NoComment({
   url = normalizeURL(location.href),
   relays = [],
+  owner,
   skip
 }) {
   const [notices, setNotices] = useState([])
@@ -254,12 +255,18 @@ export function NoComment({
     if (!root) {
       // create base event right here
       let sk = generatePrivateKey()
+      let tags = [
+        ['r', url],
+      ];
+      if (owner !== '') {
+        tags.push(['p', owner])
+      }
       root = {
         pubkey: getPublicKey(sk),
         created_at: Math.round(Date.now() / 1000),
         kind: 1,
-        tags: [['r', url]],
-        content: `Comments on ${url} ↴`
+        tags: tags,
+        content: `Comments on ${url}` + (owner !== '' ? ` by #[1]` : '') + ` ↴`
       }
       root.id = getEventHash(root)
       root.sig = signEvent(root, sk)


### PR DESCRIPTION
This change allows tagging the blog/website owner in the root post so they get notifications of comments in Nostr.