### PR TITLE
Fixed missing colon in 'a' tag

### DIFF
--- a/src/NoComment.jsx
+++ b/src/NoComment.jsx
@@ -51,10 +51,10 @@ export function NoComment({
         case 'naddr':
           const {kind, pubkey, identifier} = data
           customBaseTag = {
-            filter: {'#a': [`${kind}:${pubkey}${identifier}`]},
+            filter: {'#a': [`${kind}:${pubkey}:${identifier}`]},
             reference: [
               'a',
-              `${kind}:${pubkey}${identifier}`,
+              `${kind}:${pubkey}:${identifier}`,
               data.relays[0] || '',
               'root'
             ]


### PR DESCRIPTION
As per [NIP-33](https://github.com/nostr-protocol/nips/blob/master/33.md) the `a` tag should have this format: `<kind>:<pubkey>:<d-identifier>`. The second colon was missing.

(I didn't have the chance to actually run this, I only saw that events generated by this plugin have the wrong `a` tag and I made this quick change. It may be incomplete or wrong).