### PR TITLE
bug fix: safeguard threads before mapping

### DIFF
--- a/src/NoComment.jsx
+++ b/src/NoComment.jsx
@@ -149,7 +149,7 @@ export function NoComment({
       {editor()}
 
       <div>
-        {threads.map(thread => (
+        {threads?.map(thread => (
           <Thread
             key={thread.id}
             thread={thread}


### PR DESCRIPTION
Embeddable script was throwing an error on first run because it running `threads.map` with threads undefined.

@fiatjaf please review